### PR TITLE
patch(translator): add support for wasm

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libxtst-dev libevdev-dev libxdo-dev
-          version: 1.0
 
       - name: Add components
         run: rustup component add clippy
@@ -29,7 +25,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Clippy
-        run: cargo clippy -p afrim-translator -p afrim-memory -p afrim-preprocessor --target wasm32-unknown-unknown --all-features
+        run: cargo clippy -p afrim-config -p afrim-translator -p afrim-memory -p afrim-preprocessor --target wasm32-unknown-unknown --all-features
 
       - name: Build
-        run: cargo build -p afrim-translator -p afrim-memory -p afrim-preprocessor --target wasm32-unknown-unknown --all-features
+        run: cargo build -p afrim-config -p afrim-translator -p afrim-memory -p afrim-preprocessor --target wasm32-unknown-unknown --all-features

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -13,9 +13,10 @@ authors = ["Brady Fomegne <fomegnemeudje@outlook.com>"]
 [features]
 default = ["rhai"]
 rhai = ["dep:rhai"]
+rhai-wasm = ["rhai", "rhai/wasm-bindgen"]
 
 [dependencies]
-rhai = { version = "1.16.3", optional = true }
+rhai = { version = "1.16.3", optional = true, features = ["only_i32", "f32_float", "no_custom_syntax"] }
 indexmap = { version = "2.1.0", features = ["serde"] }
 serde = { version = "1.0.192", features = ["derive"] }
 toml = "0.8.8"


### PR DESCRIPTION
### Problem
The afrim-config was not able to be used in a wasm32 platform.

### Change
Add the possibility to customize the way that data should be read.