### PR TITLE
ci: resume the sandbox test on macos

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,8 +22,6 @@ jobs:
         include:
         - os: ubuntu-latest
           headless: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        - os: macos-latest
-          extra: -- --skip test_simple
 
     steps:
       - uses: actions/checkout@v3
@@ -52,11 +50,10 @@ jobs:
         run: cargo build --all-features --verbose
 
       - name: Run tests (minimal)
-        run: cargo test --no-default-features --lib --bins --tests --verbose ${{matrix.extra}}
+        run: cargo test --no-default-features --lib --bins --tests --verbose
 
       - name: Run tests (normal)
-        run: cargo test --lib --bins --tests --verbose ${{matrix.extra}}
+        run: cargo test --lib --bins --tests --verbose
         
       - name: Run tests (full)
-        run: cargo test --all-features --lib --bins --tests --verbose ${{matrix.extra}}
-
+        run: cargo test --all-features --lib --bins --tests --verbose


### PR DESCRIPTION
According to the update in the macOS runner, we should be able to have access to the accessibility mode.
Then, we can perform our tests without problem.

### Useful links
- https://github.com/actions/runner-images/issues/7269