### PR TITLE
fix(preprocessor): replace the term stack by queue

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -135,7 +135,7 @@ pub fn run(config: Config, mut frontend: impl Frontend) -> Result<(), Box<dyn er
         }
 
         // Process preprocessor instructions
-        while let Some(command) = preprocessor.pop_stack() {
+        while let Some(command) = preprocessor.pop_queue() {
             match command {
                 Command::CommitText(text) => {
                     keyboard.key_sequence(&text);


### PR DESCRIPTION
The way that the command are stored and provided follows the queue.
The name stack can create a confusion.