### PR TITLE
chore: replace std::fs by include_str! to load test data

### DIFF
--- a/engine/preprocessor/src/lib.rs
+++ b/engine/preprocessor/src/lib.rs
@@ -625,9 +625,9 @@ mod tests {
 
     #[test]
     fn test_advanced() {
-        use std::{fs, rc::Rc};
+        use std::rc::Rc;
 
-        let data = fs::read_to_string("./data/sample.txt").unwrap();
+        let data = include_str!("../data/sample.txt");
         let data = utils::load_data(&data);
         let memory = utils::build_map(data);
         let mut preprocessor = Preprocessor::new(Rc::new(memory), 64);

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -35,11 +35,9 @@
 //!
 //! ```no_run
 //! use afrim_memory::utils;
-//! use std::fs;
 //!
-//! // Import data from a file.
-//! let data = fs::read_to_string("./data/sample.txt")
-//!                   .expect("Failed to load the data file");
+//! // Import data from a string.
+//! let data = "a1 à\ne2 é";
 //! let data = utils::load_data(&data);
 //! let text_buffer = utils::build_map(data);
 //! ```
@@ -581,7 +579,7 @@ mod tests {
     #[test]
     fn test_cursor() {
         use crate::{utils, Cursor};
-        use std::{fs, rc::Rc};
+        use std::rc::Rc;
 
         macro_rules! hit {
             ( $cursor:ident $( $c:expr ),* ) => (
@@ -597,7 +595,7 @@ mod tests {
             };
         }
 
-        let data = fs::read_to_string("./data/sample.txt").unwrap();
+        let data = include_str!("../data/sample.txt");
         let root = utils::build_map(utils::load_data(&data));
 
         let mut cursor = Cursor::new(Rc::new(root), 8);

--- a/memory/src/utils.rs
+++ b/memory/src/utils.rs
@@ -73,13 +73,11 @@ pub fn build_map(data: Vec<Vec<&str>>) -> Node {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     #[test]
     fn test_load_data() {
         use crate::utils;
 
-        let data = fs::read_to_string("./data/sample.txt").unwrap();
+        let data = include_str!("../data/sample.txt");
 
         utils::load_data(&data)
             .iter()
@@ -93,7 +91,7 @@ mod tests {
         let data = vec![vec!["af11", "ɑ̀ɑ̀"], vec!["?.", "ʔ"]];
         utils::build_map(data);
 
-        let data = fs::read_to_string("./data/sample.txt").unwrap();
+        let data = include_str!("../data/sample.txt");
         let data = utils::load_data(&data);
 
         utils::build_map(data);


### PR DESCRIPTION
Instead of load the test file in runtime, we prefer do it in compile time.
The objective is to limit the file access while the tests.