### PR TITLE
perf(translator): increase performance

### DIFF
--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -17,7 +17,7 @@ rhai = ["dep:rhai"]
 rhai-wasm = ["rhai", "rhai/wasm-bindgen"]
 
 [dependencies]
-rhai = { version = "1.17.1", optional = true, features = ["only_i32", "f32_float", "no_custom_syntax"] }
+rhai = { version = "1.17.1", optional = true, features = ["only_i32", "no_float", "no_closure", "unchecked", "no_position", "no_custom_syntax"] }
 indexmap = { version = "2.2.5", features = ["serde"] }
 serde = { version = "1.0.197", features = ["derive"] }
 toml = { version = "0.8.10", features = ["preserve_order"] }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -378,11 +378,7 @@ impl Config {
         fs: &impl FileSystem,
     ) -> Result<IndexMap<String, AST>> {
         let empty = IndexMap::default();
-        let mut engine = Engine::new();
-
-        // allow nesting up to 50 layers of expressions/statements
-        // at global level, but only 10 inside function
-        engine.set_max_expr_depths(25, 25);
+        let engine = Engine::new();
 
         self.translators
             .as_ref()

--- a/engine/translator/Cargo.toml
+++ b/engine/translator/Cargo.toml
@@ -20,7 +20,7 @@ strsim = ["dep:strsim"]
 serde = ["indexmap/serde", "rhai/serde"]
 
 [dependencies]
-rhai = { version = "1.17.1", optional = true, features = ["only_i32", "f32_float", "no_custom_syntax"] }
+rhai = { version = "1.17.1", optional = true, features = ["only_i32", "no_float", "no_closure", "unchecked", "no_position", "no_custom_syntax"] }
 indexmap = { version = "2.2.5" }
 strsim = { version = "0.11.0", optional = true }
 

--- a/engine/translator/src/lib.rs
+++ b/engine/translator/src/lib.rs
@@ -229,8 +229,6 @@ impl Translator {
     ///    }
     /// "#;
     /// let mut engine = Engine::new();
-    /// // confer: https://rhai.rs/book/safety/max-stmt-depth.html
-    /// engine.set_max_expr_depths(25, 25);
     /// let date_translator = engine.compile(date_translator).unwrap();
     ///
     /// // We build the translator.


### PR DESCRIPTION
### Related issues
- Resolved #200

### Description
Since some Rhai features are optional for us, the objective is to remove them and assess the improvement that we can achieve.

### Change
By disabling some Rhai features, we have seen an improvement of ~30%.

### Impact
- We have lost the ability to track the position during debugging of the Rhai script.
    Before: `Expecting ';' to terminate this statement (line 5, position 3)`
    Now: `Expecting ';' to terminate this statement`