### PR TITLE
ci: update the coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,13 +48,13 @@ jobs:
       - name: build
         env:
           RUSTFLAGS: -Cinstrument-coverage
-        run: cargo build -p afrim-memory -p afrim-preprocessor -p afrim-translator -p afrim-config -p afrim --verbose
+        run: cargo build --workspace --verbose
 
       - name: test
         env:
           RUSTFLAGS: -Cinstrument-coverage
           LLVM_PROFILE_FILE: name-%p-%m.profraw
-        run: cargo test -p afrim-memory -p afrim-preprocessor -p afrim-translator -p afrim-config -p afrim --verbose
+        run: cargo test --workspace --verbose
 
       - name: Run grcov
         run: |


### PR DESCRIPTION
use of --workspace option instead of -p for the cargo build/test