### PR TITLE
patch(memory): add Cursor::resume for sequence continuation

### DIFF
--- a/engine/preprocessor/src/lib.rs
+++ b/engine/preprocessor/src/lib.rs
@@ -136,6 +136,8 @@ impl Preprocessor {
 
             true
         } else {
+            self.cursor.resume();
+
             false
         }
     }
@@ -229,7 +231,6 @@ impl Preprocessor {
     ///
     /// // Verification.
     /// while let Some(command) = preprocessor.pop_queue() {
-    ///     dbg!(command.clone());
     ///     assert_eq!(command, expecteds.pop_front().unwrap());
     /// }
     /// ```


### PR DESCRIPTION
### Issue
- resolve #208 

### Change
Now, it's possible to resume a ended sequence.