### PR TITLE
Put back Kasahorow as a sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,6 @@ If you like this project, please star and share our repositories. If you feel ge
 
 ### Our sponsors
 
-We are open for sponsors.
+<a href="https://www.kasahorow.com">
+    <img src="https://www.kasahorow.com/kasahorow_com.png" width="238">
+</a>


### PR DESCRIPTION
This reverts commit d7b34f2d257ebb42eb34564b4c5b1ac69a54c6ac.

We are still under the sponsorship of [Kasahorow](https://kasahorow.com). Not really financially, but more like a project management training.